### PR TITLE
[T642]bad_connector_woocommerce:change string in product odoo_id-BAD-PAA

### DIFF
--- a/bad_connector_woocommerce/models/product/common.py
+++ b/bad_connector_woocommerce/models/product/common.py
@@ -30,7 +30,7 @@ class WooProductProduct(models.Model):
 
     odoo_id = fields.Many2one(
         comodel_name="product.product",
-        string="Product Product",
+        string="Odoo Product",
         required=True,
         ondelete="restrict",
     )


### PR DESCRIPTION
Description:

- Solve the warning message that occurred in the terminal[2023-10-16 05:19:21,846 37556 WARNING v16_CE_connector_woocommerce odoo.addons.base.models.ir_model: Two fields (product_variant_id, odoo_id) of woo.product.product() have the same label: Product. [Modules: None and bad_connector_woocommerce] 
].
