### PR TITLE
[T7146]connector_woocommerce:Added DO split functionality-BAD-PAA 

### DIFF
--- a/bad_connector_woocommerce/README.rst
+++ b/bad_connector_woocommerce/README.rst
@@ -157,6 +157,7 @@
   - When the Price Tax, recorded at the Order Line level, differs from the Total Tax Line value, recorded at the Order Line's binding level, a 'The WooCommerce Price Tax is different then Total Tax of Odoo.' Danger Banner will be displayed at the sale order level.
   - When the Amount Total, recorded at the Order level, differs from the woo Amount Total value, recorded at the Order binding level, a 'The WooCommerce Amount Total is different then Amount Total of Odoo.' Danger Banner will be displayed at the sale order level.
   - At the backend level, within the 'Connectors' section, specifically under 'WooCommerce' > 'WooCommerce Backends' in the 'Advanced Configuration' tab, there is a 'Filter Sale Orders Based on their Status' Many2many Field. When this field is populated with specific sale order statuses, it will filter and retrieve those sale orders from WooCommerce that match the statuses provided in the 'Filter Sale Orders Based on their Status' field.
+  - We can only mark the Woocommerce status to Completed if the co-responding sleorder's all delivery order are in "Done" or "Cancelled" state.
 
 * Payload Information:
     - At Partner, Product, Product Attribute, Product Attribute Value, Country, Delivery Carrier, Product Tags and Sale order binding form view level the co-responding payload can be viewed in "Woo Data" field.

--- a/bad_connector_woocommerce/README.rst
+++ b/bad_connector_woocommerce/README.rst
@@ -157,7 +157,7 @@
   - When the Price Tax, recorded at the Order Line level, differs from the Total Tax Line value, recorded at the Order Line's binding level, a 'The WooCommerce Price Tax is different then Total Tax of Odoo.' Danger Banner will be displayed at the sale order level.
   - When the Amount Total, recorded at the Order level, differs from the woo Amount Total value, recorded at the Order binding level, a 'The WooCommerce Amount Total is different then Amount Total of Odoo.' Danger Banner will be displayed at the sale order level.
   - At the backend level, within the 'Connectors' section, specifically under 'WooCommerce' > 'WooCommerce Backends' in the 'Advanced Configuration' tab, there is a 'Filter Sale Orders Based on their Status' Many2many Field. When this field is populated with specific sale order statuses, it will filter and retrieve those sale orders from WooCommerce that match the statuses provided in the 'Filter Sale Orders Based on their Status' field.
-  - We can only mark the Woocommerce status to Completed if the co-responding sleorder's all delivery order are in "Done" or "Cancelled" state.
+  - To set the WooCommerce status to "Completed," ensure that all corresponding sale orders have their delivery orders in either the "Done" or "Cancelled" state.
 
 * Payload Information:
     - At Partner, Product, Product Attribute, Product Attribute Value, Country, Delivery Carrier, Product Tags and Sale order binding form view level the co-responding payload can be viewed in "Woo Data" field.

--- a/bad_connector_woocommerce/models/sale_order/importer.py
+++ b/bad_connector_woocommerce/models/sale_order/importer.py
@@ -337,16 +337,25 @@ class WooSaleOrderImporter(Component):
         product_ids = []
         tax_ids = []
         for line in record.get("line_items", []):
-            if line["product_id"] in product_ids:
+            product_id = (
+                line["variation_id"]
+                if line["variation_id"] != 0
+                else line["product_id"]
+            )
+
+            if product_id in product_ids:
                 continue
-            product_ids.append(line["product_id"])
+
+            product_ids.append(product_id)
+
             lock_name = "import({}, {}, {}, {})".format(
                 self.backend_record._name,
                 self.backend_record.id,
                 "woo.product.product",
-                line["product_id"],
+                product_id,
             )
             self.advisory_lock_or_retry(lock_name)
+
         for tax_line in record.get("tax_lines", []):
             if tax_line["rate_id"] in tax_ids:
                 continue
@@ -371,10 +380,16 @@ class WooSaleOrderImporter(Component):
             _logger.debug("line: %s", line)
             if "rate_id" in tax_line:
                 self._import_dependency(tax_line["rate_id"], "woo.tax")
+
         for line in record.get("line_items", []):
             _logger.debug("line: %s", line)
             if "product_id" in line:
-                self._import_dependency(line["product_id"], "woo.product.product")
+                product_id = (
+                    line["variation_id"]
+                    if line["variation_id"] != 0
+                    else line["product_id"]
+                )
+                self._import_dependency(product_id, "woo.product.product")
 
         for shipping_line in record.get("shipping_lines", []):
             _logger.debug("shipping_line: %s", shipping_line)
@@ -398,14 +413,10 @@ class WooSaleOrderLineImportMapper(Component):
     ]
 
     def get_product(self, record):
-        """Get The Binding of Product"""
-        product_rec = record.get("product_id")
-        if not product_rec:
-            return False
+        """Get the Binding of Product"""
+        product_id = record.get("variation_id", 0) or record.get("product_id", 0)
         binder = self.binder_for("woo.product.product")
-        product = binder.to_internal(product_rec, unwrap=True)
-        if not product:
-            product = binder.to_internal(record.get("variation_id"), unwrap=True)
+        product = binder.to_internal(product_id, unwrap=True)
         return product
 
     @mapping

--- a/bad_connector_woocommerce/models/woo_backend/common.py
+++ b/bad_connector_woocommerce/models/woo_backend/common.py
@@ -495,6 +495,7 @@ class WooBackend(models.Model):
                     ("woo_bind_ids.backend_id", "=", backend.id),
                     ("is_final_status", "!=", True),
                     ("picking_ids.state", "=", "done"),
+                    ("has_done_picking", "=", True),
                 ]
             )
             for sale_order in sale_orders:

--- a/bad_connector_woocommerce/models/woo_backend/common.py
+++ b/bad_connector_woocommerce/models/woo_backend/common.py
@@ -494,7 +494,6 @@ class WooBackend(models.Model):
                 [
                     ("woo_bind_ids.backend_id", "=", backend.id),
                     ("is_final_status", "!=", True),
-                    ("picking_ids.state", "=", "done"),
                     ("has_done_picking", "=", True),
                 ]
             )

--- a/bad_connector_woocommerce/views/sale_order_view.xml
+++ b/bad_connector_woocommerce/views/sale_order_view.xml
@@ -60,7 +60,7 @@
                     name="export_delivery_status"
                     type="object"
                     class="oe_highlight"
-                    attrs="{'invisible': ['|','|',('is_final_status','=',True),('has_done_picking', '=', False),('woo_bind_ids','=',False)]}"
+                    attrs="{'invisible': ['|','|',('is_final_status','=',True),('has_done_picking', '=', False),('woo_bind_ids','=',[])]}"
                     string="Export Delivery Status"
                 />
             </xpath>
@@ -85,7 +85,11 @@
                 expr="//form/sheet/group/group/field[@name='payment_term_id']"
                 position="after"
             >
-                <field name="woo_payment_mode_id" />
+                <field
+                    name="woo_payment_mode_id"
+                    attrs="{'invisible': [('woo_bind_ids', '=', [])]}"
+                />
+                <field name="woo_bind_ids" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='order_line']//tree" position="attributes">
                 <attribute name="editable" />


### PR DESCRIPTION
Task Description:

- DO should be in Done/Canceled state in odoo then only mark "completed" of sale order in woocommerce.
- If there are 2 DO in one SO then it should be in the Done/canceled state then only can we export the sale order status to the Complete state.

Note :- The above two functionality was already implemented in the previous release of connector-woocommerce.


- Import dependency of order is fixed that allows to import variant if variant type product in order is selected.
- Export delivery status button will only be visible if all the necessary requirement is fulfilled.
- Woocommerce Payment Mode field is now only visible if the sale order is imported from Woocommerce.
